### PR TITLE
fix: lowercase external metrics names

### DIFF
--- a/internal/provider/newrelic/provider.go
+++ b/internal/provider/newrelic/provider.go
@@ -90,8 +90,8 @@ func isValidExternalMetricName(name string) error {
 		return fmt.Errorf("may not contain uppercase char")
 	}
 
-	if err := path.IsValidPathSegmentName(name); len(err) != 0 {
-		return fmt.Errorf("%v", err)
+	if errs := path.IsValidPathSegmentName(name); len(errs) != 0 {
+		return fmt.Errorf("is not a valid path segment name: %v", strings.Join(errs, ","))
 	}
 
 	return nil

--- a/internal/provider/newrelic/provider_test.go
+++ b/internal/provider/newrelic/provider_test.go
@@ -488,7 +488,7 @@ func Test_Creating_provider_returns_error_when(t *testing.T) {
 		"any_of_configured_external_metric_names_is_not_a_valid_path_segment": func(o *newrelic.ProviderOptions) {
 			o.ExternalMetrics["test/"] = newrelic.Metric{}
 		},
-		"any_of_configured_external_metric_has_uppercase_characters_in_name": func(o *newrelic.ProviderOptions) {
+		"any_of_configured_external_metrics_has_uppercase_character_in_name": func(o *newrelic.ProviderOptions) {
 			o.ExternalMetrics["Test"] = newrelic.Metric{}
 		},
 	}


### PR DESCRIPTION
This PR adds the lowercasing of external metrics names and prints a warning if any metric has been configured using an upper case char.
 
- [x] e2e tests 

fixes #3 
fixes #18 