### PR TITLE
Run release pipeline again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,7 @@ jobs:
     name: Integration and e2e tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [ "build", "chart-lint" ]
+    needs: [ "build" ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2


### PR DESCRIPTION
Yesterday’s Github outage did not run pipelines when #40 was merged to main. I am doing this quick and stupid PR to force a run of the pipeline to release the helm chart.

It is based on the review @roobre gave @paologallinaharbur [here](https://github.com/newrelic/nri-kubernetes/pull/377#discussion_r834463880) and fixed [here](https://github.com/newrelic/nri-kubernetes/pull/377/commits/78a9c38da16ed3f9151ada0173ce58ecd91d3b5f).