### PR TITLE
Upgrade common library to 1.x

### DIFF
--- a/charts/newrelic-k8s-metrics-adapter/Chart.lock
+++ b/charts/newrelic-k8s-metrics-adapter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: https://helm-charts.newrelic.com
-  version: 0.17.0
-digest: sha256:2d99075b5c61591704a71ba077d1d7f774cc39a48b9a96a81d2129ff563a15ba
-generated: "2022-04-05T16:04:48.3417+02:00"
+  version: 1.0.1
+digest: sha256:df6f762ddd1cb5836e12d4a5e8b3d09abee2cc623382242796754a1d8f2e61b6
+generated: "2022-04-13T17:37:08.758909+02:00"

--- a/charts/newrelic-k8s-metrics-adapter/Chart.lock
+++ b/charts/newrelic-k8s-metrics-adapter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: https://helm-charts.newrelic.com
-  version: 1.0.1
-digest: sha256:df6f762ddd1cb5836e12d4a5e8b3d09abee2cc623382242796754a1d8f2e61b6
-generated: "2022-04-13T17:37:08.758909+02:00"
+  version: 1.0.2
+digest: sha256:22d56c5e643d46e9a1675354595ca6832a0f4db8422d89cb7db73a3b0d0d7873
+generated: "2022-04-21T12:45:30.433112+02:00"

--- a/charts/newrelic-k8s-metrics-adapter/Chart.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy the New Relic Kubernetes Metrics Adapter.
 name: newrelic-k8s-metrics-adapter
-version: 0.7.1
+version: 0.7.2
 appVersion: 0.3.0
 home: https://hub.docker.com/r/newrelic/newrelic-k8s-metrics-adapter
 sources:
@@ -11,7 +11,7 @@ icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 
 dependencies:
   - name: common-library
-    version: 0.17.0
+    version: 1.0.1
     repository: "https://helm-charts.newrelic.com"
 
 maintainers:

--- a/charts/newrelic-k8s-metrics-adapter/Chart.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/Chart.yaml
@@ -11,7 +11,7 @@ icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 
 dependencies:
   - name: common-library
-    version: 1.0.1
+    version: 1.0.2
     repository: "https://helm-charts.newrelic.com"
 
 maintainers:

--- a/charts/newrelic-k8s-metrics-adapter/templates/_helpers.tpl
+++ b/charts/newrelic-k8s-metrics-adapter/templates/_helpers.tpl
@@ -1,11 +1,17 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{- /* Allow to change pod defaults dynamically based if we are running in privileged mode or not */ -}}
-{{- define "common.securityContext.podDefaults" -}}
+{{- define "newrelic-k8s-metrics-adapter.securityContext.pod" -}}
+{{- if include "newrelic.common.securityContext.pod" . -}}
+{{- include "newrelic.common.securityContext.pod" . -}}
+{{- else -}}
 fsGroup: 1001
 runAsUser: 1001
 runAsGroup: 1001
 {{- end -}}
+{{- end -}}
+
+
 
 {{/*
 Select a value for the region

--- a/charts/newrelic-k8s-metrics-adapter/templates/_helpers.tpl
+++ b/charts/newrelic-k8s-metrics-adapter/templates/_helpers.tpl
@@ -14,9 +14,9 @@ When this value is empty the New Relic client region will be the default 'US'
 {{- define "newrelic-k8s-metrics-adapter.region" -}}
 {{- if .Values.config.region -}}
   {{- .Values.config.region | upper -}}
-{{- else if (include "common.nrStaging" .)  -}}
+{{- else if (include "newrelic.common.nrStaging" .)  -}}
 Staging
-{{- else if hasPrefix "eu" (include "common.license._licenseKey" .) -}}
+{{- else if hasPrefix "eu" (include "newrelic.common.license._licenseKey" .) -}}
 EU
 {{- end -}}
 {{- end -}}

--- a/charts/newrelic-k8s-metrics-adapter/templates/_helpers.tpl
+++ b/charts/newrelic-k8s-metrics-adapter/templates/_helpers.tpl
@@ -26,3 +26,24 @@ Staging
 EU
 {{- end -}}
 {{- end -}}
+
+
+
+{{- /*
+Naming helpers
+*/ -}}
+{{- define "newrelic-k8s-metrics-adapter.name.apiservice" -}}
+{{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "apiservice") }}
+{{- end -}}
+
+{{- define "newrelic-k8s-metrics-adapter.name.apiservice-create" -}}
+{{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "apiservice-create") }}
+{{- end -}}
+
+{{- define "newrelic-k8s-metrics-adapter.name.apiservice-patch" -}}
+{{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "apiservice-patch") }}
+{{- end -}}
+
+{{- define "newrelic-k8s-metrics-adapter.name.hpa-controller" -}}
+{{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "hpa-controller") }}
+{{- end -}}

--- a/charts/newrelic-k8s-metrics-adapter/templates/adapter-clusterrolebinding.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/adapter-clusterrolebinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "common.naming.fullname" . }}:system:auth-delegator
+  name: {{ include "newrelic.common.naming.fullname" . }}:system:auth-delegator
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: system:auth-delegator
 subjects:
 - kind: ServiceAccount
-  name: {{ include "common.serviceAccount.name" . }}
+  name: {{ include "newrelic.common.serviceAccount.name" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/adapter-rolebinding.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/adapter-rolebinding.yaml
@@ -1,15 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "common.naming.fullname" . }}
+  name: {{ include "newrelic.common.naming.fullname" . }}
   namespace: kube-system
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: extension-apiserver-authentication-reader
 subjects:
 - kind: ServiceAccount
-  name: {{ include "common.serviceAccount.name" . }}
+  name: {{ include "newrelic.common.serviceAccount.name" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/apiservice.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/apiservice.yaml
@@ -3,15 +3,15 @@ kind: APIService
 metadata:
   name: v1beta1.external.metrics.k8s.io
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 {{- if .Values.certManager.enabled }}
   annotations:
-    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-root-cert" .Release.Namespace (include "common.naming.fullname" .) | quote }}
-    cert-manager.io/inject-ca-from: {{ printf "%s/%s-root-cert" .Release.Namespace (include "common.naming.fullname" .) | quote }}
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-root-cert" .Release.Namespace (include "newrelic.common.naming.fullname" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-root-cert" .Release.Namespace (include "newrelic.common.naming.fullname" .) | quote }}
 {{- end }}
 spec:
   service:
-    name: {{ template "common.naming.fullname" . }}
+    name: {{ include "newrelic.common.naming.fullname" . }}
     namespace: {{ .Release.Namespace }}
   group: external.metrics.k8s.io
   version: v1beta1

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/clusterrole.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/clusterrole.yaml
@@ -2,12 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "common.naming.fullname" . }}-apiservice
+  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - apiregistration.k8s.io
@@ -20,5 +20,5 @@ rules:
     resources: ['podsecuritypolicies']
     verbs: ['use']
     resourceNames:
-    - {{ template "common.naming.fullname" . }}-apiservice
+    - {{ include "newrelic.common.naming.fullname" . }}-apiservice
 {{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/clusterrole.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice
+  name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -20,5 +20,5 @@ rules:
     resources: ['podsecuritypolicies']
     verbs: ['use']
     resourceNames:
-    - {{ include "newrelic.common.naming.fullname" . }}-apiservice
+    - {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
 {{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/clusterrolebinding.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice
+  name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -11,9 +11,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice
+  name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "newrelic.common.serviceAccount.name" . }}-apiservice
+    name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/clusterrolebinding.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/clusterrolebinding.yaml
@@ -2,18 +2,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "common.naming.fullname" . }}-apiservice
+  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "common.naming.fullname" . }}-apiservice
+  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice
 subjects:
   - kind: ServiceAccount
-    name: {{ include "common.serviceAccount.name" . }}-apiservice
+    name: {{ include "newrelic.common.serviceAccount.name" . }}-apiservice
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-createSecret.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-createSecret.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice-create
+  name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice-create" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -12,7 +12,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ include "newrelic.common.naming.fullname" . }}-apiservice-create
+      name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice-create" . }}
       labels:
         {{- include "newrelic.common.labels" . | nindent 8 }}
     spec:
@@ -28,7 +28,7 @@ spec:
             - create
             - --host={{ include "newrelic.common.naming.fullname" . }},{{ include "newrelic.common.naming.fullname" . }}.{{ .Release.Namespace }}.svc
             - --namespace={{ .Release.Namespace }}
-            - --secret-name={{ include "newrelic.common.naming.fullname" . }}-apiservice
+            - --secret-name={{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
             - --cert-name=tls.crt
             - --key-name=tls.key
           {{- with .Values.apiServicePatchJob.volumeMounts }}
@@ -40,7 +40,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}-apiservice
+      serviceAccountName: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
       securityContext:
         runAsGroup: 2000
         runAsNonRoot: true

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-createSecret.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-createSecret.yaml
@@ -3,32 +3,32 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ template "common.naming.fullname" . }}-apiservice-create
+  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice-create
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 spec:
   template:
     metadata:
-      name: {{ template "common.naming.fullname" . }}-apiservice-create
+      name: {{ include "newrelic.common.naming.fullname" . }}-apiservice-create
       labels:
-        {{- include "common.labels" . | nindent 8 }}
+        {{- include "newrelic.common.labels" . | nindent 8 }}
     spec:
-      {{- with include "common.images.renderPullSecrets" ( dict "pullSecrets" (list .Values.image.pullSecrets) "context" .) }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" (list .Values.image.pullSecrets) "context" .) }}
       imagePullSecrets:
         {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: create
-          image: {{ include "common.images.image" ( dict "imageRoot" .Values.apiServicePatchJob.image "context" .) }}
+          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.apiServicePatchJob.image "context" .) }}
           imagePullPolicy: {{ .Values.apiServicePatchJob.image.pullPolicy }}
           args:
             - create
-            - --host={{ template "common.naming.fullname" . }},{{ template "common.naming.fullname" . }}.{{ .Release.Namespace }}.svc
+            - --host={{ include "newrelic.common.naming.fullname" . }},{{ include "newrelic.common.naming.fullname" . }}.{{ .Release.Namespace }}.svc
             - --namespace={{ .Release.Namespace }}
-            - --secret-name={{ template "common.naming.fullname" . }}-apiservice
+            - --secret-name={{ include "newrelic.common.naming.fullname" . }}-apiservice
             - --cert-name=tls.crt
             - --key-name=tls.key
           {{- with .Values.apiServicePatchJob.volumeMounts }}
@@ -40,12 +40,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "common.serviceAccount.name" . }}-apiservice
+      serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}-apiservice
       securityContext:
         runAsGroup: 2000
         runAsNonRoot: true
         runAsUser: 2000
-      {{- with include "common.tolerations" . }}
+      {{- with include "newrelic.common.tolerations" . }}
       tolerations:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-patchAPIService.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-patchAPIService.yaml
@@ -3,31 +3,31 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ template "common.naming.fullname" . }}-apiservice-patch
+  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice-patch
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 spec:
   template:
     metadata:
-      name: {{ template "common.naming.fullname" . }}-apiservice-patch
+      name: {{ include "newrelic.common.naming.fullname" . }}-apiservice-patch
       labels:
-        {{- include "common.labels" . | nindent 8 }}
+        {{- include "newrelic.common.labels" . | nindent 8 }}
     spec:
-      {{- with include "common.images.renderPullSecrets" ( dict "pullSecrets" (list .Values.image.pullSecrets) "context" .) }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" (list .Values.image.pullSecrets) "context" .) }}
       imagePullSecrets:
         {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: patch
-          image: {{ include "common.images.image" ( dict "imageRoot" .Values.apiServicePatchJob.image "context" .) }}
+          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.apiServicePatchJob.image "context" .) }}
           imagePullPolicy: {{ .Values.apiServicePatchJob.image.pullPolicy }}
           args:
             - patch
             - --namespace={{ .Release.Namespace }}
-            - --secret-name={{ template "common.naming.fullname" . }}-apiservice
+            - --secret-name={{ include "newrelic.common.naming.fullname" . }}-apiservice
             - --apiservice-name=v1beta1.external.metrics.k8s.io
             {{- with .Values.apiServicePatchJob.volumeMounts }}
           volumeMounts:
@@ -38,12 +38,12 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "common.serviceAccount.name" . }}-apiservice
+      serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}-apiservice
       securityContext:
         runAsGroup: 2000
         runAsNonRoot: true
         runAsUser: 2000
-      {{- with include "common.tolerations" . }}
+      {{- with include "newrelic.common.tolerations" . }}
       tolerations:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-patchAPIService.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-patchAPIService.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice-patch
+  name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice-patch" . }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -12,7 +12,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ include "newrelic.common.naming.fullname" . }}-apiservice-patch
+      name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice-patch" . }}
       labels:
         {{- include "newrelic.common.labels" . | nindent 8 }}
     spec:
@@ -27,7 +27,7 @@ spec:
           args:
             - patch
             - --namespace={{ .Release.Namespace }}
-            - --secret-name={{ include "newrelic.common.naming.fullname" . }}-apiservice
+            - --secret-name={{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
             - --apiservice-name=v1beta1.external.metrics.k8s.io
             {{- with .Values.apiServicePatchJob.volumeMounts }}
           volumeMounts:
@@ -38,7 +38,7 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}-apiservice
+      serviceAccountName: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
       securityContext:
         runAsGroup: 2000
         runAsNonRoot: true

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/psp.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/psp.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice
+  name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/psp.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/psp.yaml
@@ -2,12 +2,12 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "common.naming.fullname" . }}-apiservice
+  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/role.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/role.yaml
@@ -3,12 +3,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ template "common.naming.fullname" . }}-apiservice
+  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/role.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice
+  name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/rolebinding.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/rolebinding.yaml
@@ -3,18 +3,18 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ template "common.naming.fullname" . }}-apiservice
+  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "common.naming.fullname" . }}-apiservice
+  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice
 subjects:
   - kind: ServiceAccount
-    name: {{ include "common.serviceAccount.name" . }}-apiservice
+    name: {{ include "newrelic.common.serviceAccount.name" . }}-apiservice
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/rolebinding.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice
+  name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -12,9 +12,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "newrelic.common.naming.fullname" . }}-apiservice
+  name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "newrelic.common.serviceAccount.name" . }}-apiservice
+    name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/serviceaccount.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "newrelic.common.serviceAccount.name" . }}-apiservice
+  name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/serviceaccount.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "common.serviceAccount.name" . }}-apiservice
+  name: {{ include "newrelic.common.serviceAccount.name" . }}-apiservice
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -13,5 +13,5 @@ metadata:
     # We submitted this PR to fix the issue: https://github.com/helm/helm/pull/10787
     "helm.sh/hook-weight": "-1"
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/configmap.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/configmap.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ template "common.naming.fullname" . }}
+  name: {{ include "newrelic.common.naming.fullname" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 data:
   config.yaml: |
     accountID: {{ .Values.config.accountID | required "config.accountID is required" }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/deployment.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
       volumes:
       - name: tls-key-cert-pair
         secret:
-          secretName: {{ include "newrelic.common.naming.fullname" . }}-apiservice
+          secretName: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
       - name: config
         configMap:
           name: {{ include "newrelic.common.naming.fullname" .  }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/deployment.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/deployment.yaml
@@ -2,14 +2,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ template "common.naming.fullname" . }}
+  name: {{ include "newrelic.common.naming.fullname" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      {{- include "newrelic.common.labels.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -19,22 +19,22 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "common.labels" . | nindent 8 }}
+        {{- include "newrelic.common.labels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "common.serviceAccount.name" . }}
-      {{- with include "common.securityContext.pod" . }}
+      serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
+      {{- with include "newrelic.common.securityContext.pod" . }}
       securityContext:
         {{- . | nindent 8 }}
       {{- end }}
-      {{- with include "common.images.renderPullSecrets" ( dict "pullSecrets" (list .Values.image.pullSecrets) "context" .) }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" (list .Values.image.pullSecrets) "context" .) }}
       imagePullSecrets:
         {{- . | nindent 8 }}
       {{- end }}
       containers:
-      - name: {{ template "common.naming.name" . }}
-        image: {{ include "common.images.image" ( dict "imageRoot" .Values.image "context" .) }}
+      - name: {{ include "newrelic.common.naming.name" . }}
+        image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.image "context" .) }}
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-        {{- with include "common.securityContext.container" . }}
+        {{- with include "newrelic.common.securityContext.container" . }}
         securityContext:
           {{- . | nindent 10 }}
         {{- end }}
@@ -58,13 +58,13 @@ spec:
         {{- end }}
         env:
         - name: CLUSTER_NAME
-          value: {{ include "common.cluster" . }}
+          value: {{ include "newrelic.common.cluster" . }}
         - name: NEWRELIC_API_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "common.naming.fullname" . }}
+              name: {{ include "newrelic.common.naming.fullname" . }}
               key: personalAPIKey
-        {{- with (include "common.proxy" .) }}
+        {{- with (include "newrelic.common.proxy" .) }}
         - name: HTTPS_PROXY
           value: {{ . }}
         {{- end }}
@@ -85,30 +85,30 @@ spec:
       volumes:
       - name: tls-key-cert-pair
         secret:
-          secretName: {{ template "common.naming.fullname" . }}-apiservice
+          secretName: {{ include "newrelic.common.naming.fullname" . }}-apiservice
       - name: config
         configMap:
-          name: {{ template "common.naming.fullname" .  }}
+          name: {{ include "newrelic.common.naming.fullname" .  }}
       {{- with .Values.extraVolumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- with include "common.priorityClassName" . }}
+      {{- with include "newrelic.common.priorityClassName" . }}
       priorityClassName: {{ . }}
       {{- end }}
-      {{- with include "common.nodeSelector" . }}
+      {{- with include "newrelic.common.nodeSelector" . }}
       nodeSelector:
         {{- . | nindent 8 }}
       {{- end }}
-      {{- with include "common.tolerations" . }}
+      {{- with include "newrelic.common.tolerations" . }}
       tolerations:
         {{- . | nindent 8 }}
       {{- end }}
-      {{- with include "common.affinity" . }}
+      {{- with include "newrelic.common.affinity" . }}
       affinity:
         {{- . | nindent 8 }}
       {{- end }}
-      hostNetwork: {{ include "common.hostNetwork.value" . }}
-      {{- with include "common.dnsConfig" . }}
+      hostNetwork: {{ include "newrelic.common.hostNetwork.value" . }}
+      {{- with include "newrelic.common.dnsConfig" . }}
       dnsConfig:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/deployment.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{- include "newrelic.common.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
-      {{- with include "newrelic.common.securityContext.pod" . }}
+      {{- with include "newrelic-k8s-metrics-adapter.securityContext.pod" . }}
       securityContext:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/hpa-clusterrole.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/hpa-clusterrole.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "common.naming.fullname" . }}:external-metrics
+  name: {{ include "newrelic.common.naming.fullname" . }}:external-metrics
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - external.metrics.k8s.io

--- a/charts/newrelic-k8s-metrics-adapter/templates/hpa-clusterrolebinding.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/hpa-clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "newrelic.common.naming.fullname" . }}-hpa-controller
+  name: {{ include "newrelic-k8s-metrics-adapter.name.hpa-controller" . }}
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
 roleRef:

--- a/charts/newrelic-k8s-metrics-adapter/templates/hpa-clusterrolebinding.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/hpa-clusterrolebinding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "common.naming.fullname" . }}-hpa-controller
+  name: {{ include "newrelic.common.naming.fullname" . }}-hpa-controller
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "common.naming.fullname" .  }}:external-metrics
+  name: {{ include "newrelic.common.naming.fullname" .  }}:external-metrics
 subjects:
 - kind: ServiceAccount
   name: horizontal-pod-autoscaler

--- a/charts/newrelic-k8s-metrics-adapter/templates/secret.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/secret.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ template "common.naming.fullname" . }}
+  name: {{ include "newrelic.common.naming.fullname" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   personalAPIKey: {{ .Values.personalAPIKey | required "personalAPIKey must be set" | quote }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/service.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/service.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ template "common.naming.fullname" . }}
+  name: {{ include "newrelic.common.naming.fullname" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}
 spec:
   ports:
   - port: 443
     targetPort: 6443
   selector:
-    {{- include "common.labels.selectorLabels" . | nindent 4 }}
+    {{- include "newrelic.common.labels.selectorLabels" . | nindent 4 }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/serviceaccount.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/serviceaccount.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "common.serviceAccount.name" . }}
+  name: {{ include "newrelic.common.serviceAccount.name" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "newrelic.common.labels" . | nindent 4 }}

--- a/charts/newrelic-k8s-metrics-adapter/tests/job_patch_job_createsecret_test.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/tests/job_patch_job_createsecret_test.yaml
@@ -9,7 +9,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.name
-          value: nri-my-release-newrelic-k8s-metrics-adapter-apiservice-create
+          value: my-release-newrelic-k8s-metrics-adapter-apiservice-create
   - it: container args are correctly defined
     asserts:
       - matchRegex:

--- a/charts/newrelic-k8s-metrics-adapter/tests/job_patch_job_patchapiservice_test.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/tests/job_patch_job_patchapiservice_test.yaml
@@ -9,7 +9,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.metadata.name
-          pattern: ^.*-apiservice-patch
+          pattern: .*-apiservice-patch$
   - it: container args are correctly defined
     asserts:
       - matchRegex:
@@ -20,7 +20,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.serviceAccountName
-          pattern: ^.*-apiservice
+          pattern: .*-apiservice$
   - it: has the correct image
     set:
       personalAPIKey: 21321
@@ -31,4 +31,4 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: ^.*k8s.gcr.io/ingress-nginx/kube-webhook-certgen:latest
+          pattern: .*k8s.gcr.io/ingress-nginx/kube-webhook-certgen:latest$

--- a/charts/newrelic-k8s-metrics-adapter/values.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/values.yaml
@@ -89,6 +89,9 @@ serviceAccount:
 # -- Configure podSecurityContext
 podSecurityContext:
 
+# -- Configure containerSecurityContext
+containerSecurityContext:
+
 # -- Array to add extra environment variables
 extraEnv: []
 # -- Array to add extra envFrom


### PR DESCRIPTION
This chart used the override system we should get rid of.

This PR should upgrade the common library and fix the issue of charts overwriting each other its helpers.