### PR TITLE
fix appVersion

### DIFF
--- a/charts/newrelic-k8s-metrics-adapter/Chart.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A Helm chart to deploy the New Relic Kubernetes Metrics Adapter.
 name: newrelic-k8s-metrics-adapter
-version: 0.7.2
-appVersion: 0.3.0
+version: 0.7.3
+appVersion: 0.2.0
 home: https://hub.docker.com/r/newrelic/newrelic-k8s-metrics-adapter
 sources:
   - https://github.com/newrelic/newrelic-k8s-metrics-adapter


### PR DESCRIPTION
I don't know when and how I finished updating the image `tag`/chart's `appVersion` but I did it.

This should fix this chart making it installable.