### PR TITLE
Add CertManager certificate templates

### DIFF
--- a/charts/newrelic-k8s-metrics-adapter/templates/_helpers.tpl
+++ b/charts/newrelic-k8s-metrics-adapter/templates/_helpers.tpl
@@ -47,3 +47,15 @@ Naming helpers
 {{- define "newrelic-k8s-metrics-adapter.name.hpa-controller" -}}
 {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "hpa-controller") }}
 {{- end -}}
+
+{{- define "newrelic-k8s-metrics-adapter.fullname.self-signed-issuer" -}}
+{{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "self-signed-issuer") }}
+{{- end -}}
+
+{{- define "newrelic-k8s-metrics-adapter.fullname.root-issuer" -}}
+{{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "root-issuer") }}
+{{- end -}}
+
+{{- define "newrelic-k8s-metrics-adapter.fullname.webhook-cert" -}}
+{{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "webhook-cert") }}
+{{- end -}}

--- a/charts/newrelic-k8s-metrics-adapter/templates/cert-manager.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/cert-manager.yaml
@@ -1,0 +1,53 @@
+{{ if .Values.certManager.enabled }}
+---
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "newrelic-k8s-metrics-adapter.fullname.self-signed-issuer" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "newrelic.common.naming.fullname" . }}-root-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ include "newrelic.common.naming.fullname" . }}-root-cert
+  duration: 43800h0m0s # 5y
+  issuerRef:
+    name: {{ include "newrelic-k8s-metrics-adapter.fullname.self-signed-issuer" . }}
+  commonName: "ca.webhook.nri"
+  isCA: true
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "newrelic-k8s-metrics-adapter.fullname.root-issuer" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: {{ include "newrelic.common.naming.fullname" . }}-root-cert
+---
+
+# Finally, generate a serving certificate for the webhook to use
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "newrelic-k8s-metrics-adapter.fullname.webhook-cert" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
+  duration: 8760h0m0s # 1y
+  issuerRef:
+    name: {{ include "newrelic-k8s-metrics-adapter.fullname.root-issuer" . }}
+  dnsNames:
+  - {{ include "newrelic.common.naming.fullname" . }}
+  - {{ include "newrelic.common.naming.fullname" . }}.{{ .Release.Namespace }}
+  - {{ include "newrelic.common.naming.fullname" . }}.{{ .Release.Namespace }}.svc
+{{ end }}


### PR DESCRIPTION
Add CertManager certificate templates

I was trying to install the NewRelic metrics-adapter  with `CertManager: true`
It was failing to create the container due to the reason `missing Volume mount `tls-key-cert-pair` 

Found out that this chart misses the CertManager  Certificates.

This PR add the CertManager templates and fixes the installation.
