### PR TITLE
 [helm chart] Patch job should also honor the global service account flag

### DIFF
--- a/charts/newrelic-k8s-metrics-adapter/Chart.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy the New Relic Kubernetes Metrics Adapter.
 name: newrelic-k8s-metrics-adapter
-version: 0.7.6
+version: 0.7.7
 appVersion: 0.2.0
 home: https://hub.docker.com/r/newrelic/newrelic-k8s-metrics-adapter
 sources:

--- a/charts/newrelic-k8s-metrics-adapter/templates/_helpers.tpl
+++ b/charts/newrelic-k8s-metrics-adapter/templates/_helpers.tpl
@@ -36,6 +36,14 @@ Naming helpers
 {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "apiservice") }}
 {{- end -}}
 
+{{- define "newrelic-k8s-metrics-adapter.name.apiservice.serviceAccount" -}}
+{{- if include "newrelic.common.serviceAccount.create" . -}}
+  {{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "apiservice") -}}
+{{- else -}}
+  {{- include "newrelic.common.serviceAccount.name" . -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "newrelic-k8s-metrics-adapter.name.apiservice-create" -}}
 {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "apiservice-create") }}
 {{- end -}}

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/clusterrolebinding.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/clusterrolebinding.yaml
@@ -14,6 +14,6 @@ roleRef:
   name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
+    name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice.serviceAccount" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-createSecret.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-createSecret.yaml
@@ -40,7 +40,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
+      serviceAccountName: {{ include "newrelic-k8s-metrics-adapter.name.apiservice.serviceAccount" . }}
       securityContext:
         runAsGroup: 2000
         runAsNonRoot: true

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-patchAPIService.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-patchAPIService.yaml
@@ -38,7 +38,7 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
+      serviceAccountName: {{ include "newrelic-k8s-metrics-adapter.name.apiservice.serviceAccount" . }}
       securityContext:
         runAsGroup: 2000
         runAsNonRoot: true

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/rolebinding.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/rolebinding.yaml
@@ -15,6 +15,6 @@ roleRef:
   name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
+    name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice.serviceAccount" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/serviceaccount.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/serviceaccount.yaml
@@ -1,4 +1,5 @@
-{{- if (and (not .Values.customTLSCertificate) (not .Values.certManager.enabled)) }}
+{{- $createServiceAccount := include "newrelic.common.serviceAccount.create" . -}}
+{{- if (and $createServiceAccount (not .Values.customTLSCertificate) (not .Values.certManager.enabled)) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/serviceaccount.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
+  name: {{ include "newrelic-k8s-metrics-adapter.name.apiservice.serviceAccount" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/newrelic-k8s-metrics-adapter/templates/serviceaccount.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/serviceaccount.yaml
@@ -1,7 +1,13 @@
+{{- if include "newrelic.common.serviceAccount.create" . -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{ .Release.Namespace }}
-  name: {{ include "newrelic.common.serviceAccount.name" . }}
+  {{- if include "newrelic.common.serviceAccount.annotations" . }}
+  annotations:
+    {{- include "newrelic.common.serviceAccount.annotations" . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
+  name: {{ include "newrelic.common.serviceAccount.name" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/tests/job_serviceaccount_test.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/tests/job_serviceaccount_test.yaml
@@ -1,0 +1,35 @@
+suite: test job' serviceAccount
+templates:
+  - templates/apiservice/job-patch/job-createSecret.yaml
+  - templates/apiservice/job-patch/job-patchAPIService.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: RBAC points to the service account that is created by default
+    set:
+      rbac.create: true
+      serviceAccount.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-release-newrelic-k8s-metrics-adapter-apiservice
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+      serviceAccount.name: sa-test
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: sa-test
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default

--- a/charts/newrelic-k8s-metrics-adapter/tests/rbac_test.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/tests/rbac_test.yaml
@@ -1,0 +1,35 @@
+suite: test RBAC creation
+templates:
+  - templates/apiservice/job-patch/rolebinding.yaml
+  - templates/apiservice/job-patch/clusterrolebinding.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: RBAC points to the service account that is created by default
+    set:
+      rbac.create: true
+      serviceAccount.create: true
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: my-release-newrelic-k8s-metrics-adapter-apiservice
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+      serviceAccount.name: sa-test
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: sa-test
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: default


### PR DESCRIPTION
There is an issue open by GTS saying that not all the charts honor the flag `.global.serviceAccount.create` and `.global.serviceAccount.name`: newrelic/helm-charts#875

There is not also the issue that they are not honored by the deployments but also by the jobs that create and patch webhook certificates.
