### PR TITLE
Bump the chart

### DIFF
--- a/charts/newrelic-k8s-metrics-adapter/Chart.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy the New Relic Kubernetes Metrics Adapter.
 name: newrelic-k8s-metrics-adapter
-version: 0.7.8
+version: 0.7.9
 appVersion: 0.2.0
 home: https://hub.docker.com/r/newrelic/newrelic-k8s-metrics-adapter
 sources:


### PR DESCRIPTION
We had a clash of chart versions after pipelines passed:

- https://github.com/newrelic/newrelic-k8s-metrics-adapter/pull/75
- https://github.com/newrelic/newrelic-k8s-metrics-adapter/pull/76

So, I am bumping and releasing the chart.