### PR TITLE
[chart] Fix `podLabels`

### DIFF
--- a/charts/newrelic-k8s-metrics-adapter/Chart.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy the New Relic Kubernetes Metrics Adapter.
 name: newrelic-k8s-metrics-adapter
-version: 0.7.9
+version: 0.7.10
 appVersion: 0.2.0
 home: https://hub.docker.com/r/newrelic/newrelic-k8s-metrics-adapter
 sources:

--- a/charts/newrelic-k8s-metrics-adapter/templates/deployment.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "newrelic.common.labels" . | nindent 8 }}
+        {{- include "newrelic.common.labels.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
       {{- with include "newrelic-k8s-metrics-adapter.securityContext.pod" . }}


### PR DESCRIPTION
We were using `labels` instead of `podLabels` in the pods so we were not leveraging the `common-library` properly.

Fixes newrelic/nri-kube-events#142