### PR TITLE
NEWRELIC-3912 Add nodeSelector support for jobs 

### DIFF
--- a/charts/newrelic-k8s-metrics-adapter/Chart.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy the New Relic Kubernetes Metrics Adapter.
 name: newrelic-k8s-metrics-adapter
-version: 0.7.11
+version: 0.7.12
 appVersion: 0.2.0
 home: https://hub.docker.com/r/newrelic/newrelic-k8s-metrics-adapter
 sources:

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-createSecret.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-createSecret.yaml
@@ -45,6 +45,10 @@ spec:
         runAsGroup: 2000
         runAsNonRoot: true
         runAsUser: 2000
+      {{- with include "newrelic.common.nodeSelector" . }}
+      nodeSelector:
+        {{- . | nindent 8 -}}
+      {{- end }}
       {{- with include "newrelic.common.tolerations" . }}
       tolerations:
         {{- . | nindent 8 }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-patchAPIService.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-patchAPIService.yaml
@@ -43,6 +43,10 @@ spec:
         runAsGroup: 2000
         runAsNonRoot: true
         runAsUser: 2000
+      {{- with include "newrelic.common.nodeSelector" . }}
+      nodeSelector:
+        {{- . | nindent 8 -}}
+      {{- end }}
       {{- with include "newrelic.common.tolerations" . }}
       tolerations:
         {{- . | nindent 8 }}


### PR DESCRIPTION
Relates to https://github.com/newrelic/helm-charts/issues/932.

NodeSelectors are not being honoured in the jobs objects.