### PR TITLE
Disable PSP by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
             fi
           done
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.4.3
+        uses: manusa/actions-setup-minikube@v2.7.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
           minikube version: v1.27.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        kubernetes-version: [ "v1.16.15", "v1.22.0" ]
+        kubernetes-version: [ "v1.16.15", "v1.22.0", "v1.25.3" ]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -97,7 +97,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.4.3
         if: steps.list-changed.outputs.changed == 'true'
         with:
-          minikube version: v1.20.0
+          minikube version: v1.27.1
           kubernetes version: ${{ matrix.kubernetes-version }}
           github token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@v2

--- a/charts/newrelic-k8s-metrics-adapter/Chart.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy the New Relic Kubernetes Metrics Adapter.
 name: newrelic-k8s-metrics-adapter
-version: 0.7.12
+version: 1.0.0
 appVersion: 0.2.0
 home: https://hub.docker.com/r/newrelic/newrelic-k8s-metrics-adapter
 sources:

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/clusterrole.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/clusterrole.yaml
@@ -16,9 +16,11 @@ rules:
     verbs:
       - get
       - update
+{{- if .Values.rbac.pspEnabled }}
   - apiGroups: ['policy']
     resources: ['podsecuritypolicies']
     verbs: ['use']
     resourceNames:
     - {{ include "newrelic-k8s-metrics-adapter.name.apiservice" . }}
+{{- end }}
 {{- end }}

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/psp.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/psp.yaml
@@ -1,4 +1,4 @@
-{{- if (and (not .Values.customTLSCertificate) (not .Values.certManager.enabled)) }}
+{{- if (and (not .Values.customTLSCertificate) (not .Values.certManager.enabled) (.Values.rbac.pspEnabled)) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/newrelic-k8s-metrics-adapter/tests/common_extra_naming_test.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/tests/common_extra_naming_test.yaml
@@ -18,6 +18,8 @@ tests:
       personalAPIKey: 21321
       config:
         accountID: 11111111
+      rbac:
+        pspEnabled: true
     asserts:
       - matchRegex:
           path: metadata.name

--- a/charts/newrelic-k8s-metrics-adapter/tests/job_patch_clusterrole_test.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/tests/job_patch_clusterrole_test.yaml
@@ -6,6 +6,9 @@ release:
   namespace: my-namespace
 tests:
   - it: PodSecurityPolicy rule resourceName is correctly defined
+    set:
+      rbac:
+        pspEnabled: true
     asserts:
       - matchRegex:
           path: rules[1].resourceNames[0]

--- a/charts/newrelic-k8s-metrics-adapter/values.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/values.yaml
@@ -146,3 +146,7 @@ apiServicePatchJob:
 certManager:
   # -- Use cert manager for APIService certs, rather than the built-in patch job.
   enabled: false
+
+rbac:
+  # rbac.pspEnabled -- Whether the chart should create Pod Security Policy objects.
+  pspEnabled: false


### PR DESCRIPTION
PSPs are removed in K8s v1.25. Attempting to install this chart in 1.25 will result in an error as the followings:

```
vtran@WG2QKVH662 newrelic-k8s-metrics-adapter % helm upgrade --install newrelic-k8s-metrics-adapter -f ./ci/test-values.yaml .
Release "newrelic-k8s-metrics-adapter" does not exist. Installing it now.
Error: failed pre-install: unable to build kubernetes object for deleting hook newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/psp.yaml: resource mapping not found for name: "newrelic-k8s-metrics-adapter-apiservice" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first
```

This PR adds a flag to control whether PSPs should be created and disables it by default. Manually testing the change on a k8s v1.25.3 minikube, no more errors as describing above. See the the following output from my testing.

```
vtran@WG2QKVH662 newrelic-k8s-metrics-adapter % helm upgrade --install newrelic-k8s-metrics-adapter -f ./ci/test-values.yaml .

Release "newrelic-k8s-metrics-adapter" has been upgraded. Happy Helming!
NAME: newrelic-k8s-metrics-adapter
LAST DEPLOYED: Mon Nov 21 11:46:01 2022
NAMESPACE: default
STATUS: deployed
REVISION: 2
TEST SUITE: None

```