### PR TITLE
Update helm chart release process

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -2,3 +2,6 @@
 # or `cl` will fail with a not-so-helpful error that says:
 # "Error linting charts: Error identifying charts to process: Error running process: exit status 128"
 target-branch: main
+
+# Charts will be released manually.
+check-version-increment: false

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -41,4 +41,5 @@ jobs:
       - name: Release workload charts
         uses: helm/chart-releaser-action@v1.3.0
         env:
+          CR_SKIP_EXISTING: true
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR makes it easier to make changes to the helm chart without needing to also bump the version in the same PR.

## Testing

- Check that future PRs that modify the chart (like https://github.com/newrelic/newrelic-k8s-metrics-adapter/pull/101) won't fail the `Helm lint` test that requires the chart version be bumped. 