### PR TITLE
Update deprecated GitHub set-output action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
         run: |
           changed=$(ct --config .github/ct.yaml list-changed)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run helm unit tests


### PR DESCRIPTION
The `set-output` command is deprecated and will be fully disabled this May:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This will clean up the warnings when running the Github workflow.