### PR TITLE
Explicitly install a controlled version of helm and kubectl

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,19 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - uses: azure/setup-kubectl@v3
+        with:
+          version: v1.25.4
+
+      - uses: azure/setup-helm@v3
+        with:
+          version: v3.10.0
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
       - uses: helm/chart-testing-action@v2.2.1
 
       - name: Add newrelic repository


### PR DESCRIPTION
Helm v3.10 uses k8s client go v0.25.2 which shouldn't
suffer from https://github.com/helm/helm/issues/11772

Once the issue is released in an upstream version of
client-go and then helm is upgraded to use it, we can
switch to that version of helm.
