### PR TITLE
Update Kubernetes image registry

### DIFF
--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-createSecret.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-createSecret.yaml
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       containers:
         - name: create
-          image: {{ include "newrelic.common.images.image" ( dict "defaultRegistry" "k8s.gcr.io" "imageRoot" .Values.apiServicePatchJob.image "context" .) }}
+          image: {{ include "newrelic.common.images.image" ( dict "defaultRegistry" "registry.k8s.io" "imageRoot" .Values.apiServicePatchJob.image "context" .) }}
           imagePullPolicy: {{ .Values.apiServicePatchJob.image.pullPolicy }}
           args:
             - create

--- a/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-patchAPIService.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/job-patchAPIService.yaml
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       containers:
         - name: patch
-          image: {{ include "newrelic.common.images.image" ( dict "defaultRegistry" "k8s.gcr.io" "imageRoot" .Values.apiServicePatchJob.image "context" .) }}
+          image: {{ include "newrelic.common.images.image" ( dict "defaultRegistry" "registry.k8s.io" "imageRoot" .Values.apiServicePatchJob.image "context" .) }}
           imagePullPolicy: {{ .Values.apiServicePatchJob.image.pullPolicy }}
           args:
             - patch

--- a/charts/newrelic-k8s-metrics-adapter/tests/job_patch_job_createsecret_test.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/tests/job_patch_job_createsecret_test.yaml
@@ -23,9 +23,9 @@ tests:
       personalAPIKey: 21321
       apiServicePatchJob:
         image:
-          repository: k8s.gcr.io/ingress-nginx/kube-webhook-certgen
+          repository: registry.k8s.io/ingress-nginx/kube-webhook-certgen
           tag: "latest"
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: ^.*k8s.gcr.io/ingress-nginx/kube-webhook-certgen:latest
+          pattern: ^.*registry.k8s.io/ingress-nginx/kube-webhook-certgen:latest

--- a/charts/newrelic-k8s-metrics-adapter/tests/job_patch_job_patchapiservice_test.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/tests/job_patch_job_patchapiservice_test.yaml
@@ -26,9 +26,9 @@ tests:
       personalAPIKey: 21321
       apiServicePatchJob:
         image:
-          repository: k8s.gcr.io/ingress-nginx/kube-webhook-certgen
+          repository: registry.k8s.io/ingress-nginx/kube-webhook-certgen
           tag: "latest"
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: .*k8s.gcr.io/ingress-nginx/kube-webhook-certgen:latest$
+          pattern: .*registry.k8s.io/ingress-nginx/kube-webhook-certgen:latest$

--- a/charts/newrelic-k8s-metrics-adapter/values.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/values.yaml
@@ -127,7 +127,7 @@ apiServicePatchJob:
   # apiServicePatchJob.image -- Registry, repository, tag, and pull policy for the job container image.
   # @default -- See `values.yaml`.
   image:
-    registry:  # defaults to k8s.gcr.io
+    registry:  # defaults to registry.k8s.io
     repository: ingress-nginx/kube-webhook-certgen
     tag: v1.3.0
     pullPolicy: IfNotPresent

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -223,7 +223,7 @@ func withTestDeployment(ctx context.Context, t *testing.T, client appsv1client.D
 					Containers: []corev1.Container{
 						{
 							Name:  "wait",
-							Image: "k8s.gcr.io/pause:3.5",
+							Image: "registry.k8s.io/pause:3.5",
 						},
 					},
 				},


### PR DESCRIPTION
k8s.gcr.io image registry will be redirected to registry.k8s.io on Monday March 20th.
All images available in k8s.gcr.io are available at registry.k8s.io.

See https://kubernetes.io/blog/2023/03/10/image-registry-redirect/
