### PR TITLE
Update Docker actions to cope with deprecated `save-state` and `set-output` commands

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -57,10 +57,10 @@ jobs:
       DOCKER_IMAGE_NAME: newrelic/newrelic-k8s-metrics-adapter
       DOCKER_PLATFORMS: "linux/amd64,linux/arm64,linux/arm" # Must be consistent with the matrix from the job above.
     steps:
-      - uses: actions/checkout@v2
-      - uses: docker/setup-qemu-action@v1
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
       - uses: docker/login-action@v2
         with:
           username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -59,9 +59,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-buildx-action@v2
       - uses: actions/download-artifact@v2
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
           password: ${{ secrets.FSI_DOCKERHUB_TOKEN }}


### PR DESCRIPTION
GitHub Actions is deprecating `save-state` and `set-output` commands. They will be fully disabled on 31st May 2023. [Source](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)