### PR TITLE
feat: remove resource usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### enhancement
+- Remove default resource assignments @cdobbyn [#188](https://github.com/newrelic/newrelic-k8s-metrics-adapter/pull/188)
 
 ## [0.4.3]
 

--- a/charts/newrelic-k8s-metrics-adapter/Chart.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy the New Relic Kubernetes Metrics Adapter.
 name: newrelic-k8s-metrics-adapter
-version: 1.2.1
+version: 1.3.0
 appVersion: 0.4.3
 home: https://hub.docker.com/r/newrelic/newrelic-k8s-metrics-adapter
 sources:

--- a/charts/newrelic-k8s-metrics-adapter/README.md
+++ b/charts/newrelic-k8s-metrics-adapter/README.md
@@ -121,7 +121,7 @@ externalMetrics:
 
 ## Resources
 
-The default set of resources assigned to the newrelic-k8s-metrics-adapter pods is shown below:
+This chart does not deploy with a default set of resources. You can specify resources for the pods by using the `resources` parameter. For example:
 
 ```yaml
 resources:

--- a/charts/newrelic-k8s-metrics-adapter/ci/test-values.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/ci/test-values.yaml
@@ -12,3 +12,11 @@ config:
 image:
   repository: e2e/newrelic-metrics-adapter
   tag: "test"  # Defaults to AppVersion
+
+resources:
+  requests:
+    cpu: 15m
+    memory: 32Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi

--- a/charts/newrelic-k8s-metrics-adapter/tests/deployment_test.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/tests/deployment_test.yaml
@@ -66,3 +66,15 @@ tests:
           path: spec.template.spec.containers[0].env[2].value
           value: localhost:1234
         template: templates/deployment.yaml
+  - it: correctly uses resources
+    asserts:
+      - equal:
+          path: spec.template.spec.resources
+          value:
+            requests:
+              cpu: 15m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+        template: templates/deployment.yaml

--- a/charts/newrelic-k8s-metrics-adapter/values.yaml
+++ b/charts/newrelic-k8s-metrics-adapter/values.yaml
@@ -71,13 +71,12 @@ image:
 replicas: 1
 
 # -- Resources you wish to assign to the pod.
-# @default -- See `values.yaml`
-resources:
-  limits:
-    memory: 80M
-  requests:
-    cpu: 100m
-    memory: 30M
+resources: {}
+# limits:
+#   memory: 80M
+# requests:
+#   cpu: 100m
+#   memory: 30M
 
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created for the job and the deployment.


### PR DESCRIPTION
## Which problem is this PR solving?
It is a common standard with helm charts to not assign default resource assignments. This is because in some cases when using `helm template` command these settings cannot be removed (even when setting a `null` value).

## Short description of the changes
Removes the default assignment of resources from the chart, leaves them as commented our recommended defaults.

## Type of change

Please delete options that are not relevant.
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## New Tests?
Please describe the new tests that were added (if applicable).

- [x] This change requires changes in testing:
  - [x] chart tests

## Checklist:

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [x] Tests have been added
- [x] Documentation has been updated