### PR TITLE
chore: Update changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,34 +5,8 @@ name: changelog
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
-  changelog-entry:
-    runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')}}
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Check for CHANGELOG file changes
-        run: |
-          # Only the latest commit of the feature branch is available
-          # automatically. To diff with the base branch, we need to
-          # fetch that too (and we only need its latest commit).
-          git fetch origin ${{ github.base_ref }} --depth=1
-          if [[ $(git diff --name-only FETCH_HEAD | grep --ignore-case CHANGELOG) ]]
-          then
-            echo "The CHANGELOG file was modified. Looks good!"
-          else
-            echo "The CHANGELOG file was not modified."
-            echo "Please add a CHANGELOG entry to the appropriate header under \"Unreleased\", or add the \"Skip Changelog\" label if not required."
-            false
-          fi
-
-  lint-changelog:
-    runs-on: ubuntu-latest
-    needs: changelog-entry
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Check if CHANGELOG is valid
-        uses: newrelic/release-toolkit/validate-markdown@v1
+  check-changelog:
+    uses: newrelic/k8s-metadata-injection/.github/workflows/changelog-reusable.yml@main


### PR DESCRIPTION
## Which problem is this PR solving?

Update changelog workflow to use reusable changelog workflow from metadata-injection repo. 

## Short description of the changes

## Type of change

Please delete options that are not relevant.
NA

## New Tests?
NA

- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated