### PR TITLE
chore: Fix CI workflow and remove old maintainers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
           kubernetes version: ${{ matrix.kubernetes-version }}
           driver: docker
           github token: ${{ secrets.GITHUB_TOKEN }}
-          start args: "--nodes=2 --container-runtime=${{ matrix.cri }}"
+          start args: "--container-runtime=${{ matrix.cri }}"
       - uses: actions/setup-go@v4
         if: steps.list-changed.outputs.changed == 'true'
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,14 +91,14 @@ jobs:
             fi
           done
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         if: steps.list-changed.outputs.changed == 'true'
         with:
-          minikube version: v1.27.1
+          minikube version: v1.30.1
           kubernetes version: ${{ matrix.kubernetes-version }}
-          container runtime: ${{ matrix.cri }}
           driver: docker
           github token: ${{ secrets.GITHUB_TOKEN }}
+          start args: "--nodes=2 --container-runtime=${{ matrix.cri }}"
       - uses: actions/setup-go@v4
         if: steps.list-changed.outputs.changed == 'true'
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
             fi
           done
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.2
+        uses: manusa/actions-setup-minikube@v2.9.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
           minikube version: v1.27.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### enhancement
+- Remove old maintainers by @svetlanabrennan [#198](https://github.com/newrelic/newrelic-k8s-metrics-adapter/pull/198)
+
 ## [0.4.3]
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### enhancement
 - Remove old maintainers by @svetlanabrennan [#198](https://github.com/newrelic/newrelic-k8s-metrics-adapter/pull/198)
 
-## [0.4.3]
+## 0.4.3
 
 ### What's Changed
 - Remove manual go cache since setup-go/v4 automatically caches by @htroisi in https://github.com/newrelic/newrelic-k8s-metrics-adapter/pull/149
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [0.4.3]: https://github.com/newrelic/newrelic-k8s-metrics-adapter/releases/tag/v0.4.3
 
-## [0.4.0]
+## 0.4.0
 
 ### Added
 
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [0.4.0]: https://github.com/newrelic/newrelic-k8s-metrics-adapter/releases/tag/v0.4.0
 
-## [0.3.0]
+## 0.3.0
 
 ### Added
 
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [0.3.0]: https://github.com/newrelic/newrelic-k8s-metrics-adapter/releases/tag/v0.3.0
 
-## [0.2.0]
+## 0.2.0
 
 ### Added
 
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [0.2.0]: https://github.com/newrelic/newrelic-k8s-metrics-adapter/releases/tag/v0.2.0
 
-## [0.1.0]
+## 0.1.0
 
 ### Added
 

--- a/charts/newrelic-k8s-metrics-adapter/README.md
+++ b/charts/newrelic-k8s-metrics-adapter/README.md
@@ -134,12 +134,6 @@ resources:
 
 ## Maintainers
 
-* [nserrino](https://github.com/nserrino)
-* [philkuz](https://github.com/philkuz)
-* [htroisi](https://github.com/htroisi)
 * [juanjjaramillo](https://github.com/juanjjaramillo)
 * [svetlanabrennan](https://github.com/svetlanabrennan)
-* [nrepai](https://github.com/nrepai)
-* [csongnr](https://github.com/csongnr)
-* [vuqtran88](https://github.com/vuqtran88)
 * [xqi-nr](https://github.com/xqi-nr)


### PR DESCRIPTION
## Which problem is this PR solving?

Remove old maintainers from readme and fix CI workflow. 

## Short description of the changes
The --container-runtime flag was deprecated in k8s 1.24, and removed in k8s 1.27
So the e2e test for 1.27.5 with minikube fails. Fixed by adding start `args: "--nodes=2 --container-runtime=${{ matrix.cri }}"` which is what we did in nri-kubenetes and nri-kube-events repo

## Type of change

Please delete options that are not relevant.

- [x] New feature / enhancement (non-breaking change which adds functionality)

## New Tests?
Please describe the new tests that were added (if applicable).

NA

- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated