### PR TITLE
fix: Add compile command to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ build: BINARY_NAME := $(if $(GOOS),$(BINARY_NAME)-$(GOOS),$(BINARY_NAME))
 build: BINARY_NAME := $(if $(GOARCH),$(BINARY_NAME)-$(GOARCH),$(BINARY_NAME))
 build: ## Compiles metrics-adapter binary.
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO_CMD) build -o $(BINARY_NAME) -v -buildmode=exe -ldflags $(LD_FLAGS) .
+compile: build
 
 .PHONY: build-test
 build-test: GO_TESTS=nonexistent


### PR DESCRIPTION
## Which problem is this PR solving?

Since we're using the release integration workflow from metadata-injection, it uses `make compile` command which doesn't exist in this repo's Makefile because it was called `make build`. 

This pr adds the `compile` command that executes the `build` command. 

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Security fix
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## New Tests?
Please describe the new tests that were added (if applicable).

- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated