### PR TITLE
fix: Tmp remove reusable workflow from release docker image

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -8,18 +8,99 @@ on:
   workflow_dispatch:
 
 jobs:
-  release-integration:
-    permissions:
-      contents: write
-      pull-requests: write
-    uses: newrelic/k8s-metadata-injection/.github/workflows/release-integration-reusable.yml@main
-    with:
-      repo_name: newrelic-k8s-metrics-adapter
-      docker_image_name: newrelic/newrelic-k8s-metrics-adapter
-      chart_directory: charts/newrelic-k8s-metrics-adapter
-    secrets:
-      dockerhub_username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
-      dockerhub_token: ${{ secrets.FSI_DOCKERHUB_TOKEN }}
-      gh_token: ${{ secrets.GITHUB_TOKEN }}
-      slack_channel: ${{ secrets.K8S_AGENTS_SLACK_CHANNEL }}
-      slack_token: ${{ secrets.K8S_AGENTS_SLACK_TOKEN }}
+  build:
+    name: Build integration for
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [ linux ]
+        goarch: [ amd64, arm64, arm ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - name: Build integration
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          make build
+      - name: Upload artifact for Docker build step
+        uses: actions/upload-artifact@v3
+        with:
+          retention-days: 1
+          name: newrelic-k8s-metrics-adapter-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: newrelic-k8s-metrics-adapter-${{ matrix.goos }}-${{ matrix.goarch }}
+
+  release:
+    name: Release Docker images
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    outputs:
+      new-version: ${{ steps.set-new-version.outputs.new-version }}
+    env:
+      DOCKER_IMAGE_NAME: newrelic/newrelic-k8s-metrics-adapter
+      DOCKER_PLATFORMS: "linux/amd64,linux/arm64,linux/arm" # Must be consistent with the matrix from the job above.
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: actions/download-artifact@v3
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.FSI_DOCKERHUB_TOKEN }}
+
+      - name: Generate Docker image version from git tag
+        run: |
+          echo "${{ github.event.release.tag_name }}" | grep -E '^v[0-9.]*[0-9]$'
+          DOCKER_IMAGE_TAG=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
+          echo "DOCKER_IMAGE_TAG=$DOCKER_IMAGE_TAG" >> $GITHUB_ENV
+          echo "new-version=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+      - name: List files
+        run: ls -la
+      - name: Build and load x64 image for security scanning
+        # We need to build a single-arch image again to be able to --load it into the host
+        run: |
+          docker buildx build --load --platform=linux/amd64 \
+            -t $DOCKER_IMAGE_NAME:ci-scan \
+            .
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.11.2
+        with:
+          image-ref: '${{ env.DOCKER_IMAGE_NAME }}:ci-scan'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'HIGH,CRITICAL'
+
+      - name: Build and push Docker prerelease images
+        if: ${{ github.event.release.prerelease }}
+        run: |
+          DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}-pre
+          docker buildx build --push --platform=$DOCKER_PLATFORMS \
+            -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
+            .
+      - name: Build and push Docker release images
+        if: ${{ ! github.event.release.prerelease }}
+        run: |
+          docker buildx build --push --platform=$DOCKER_PLATFORMS \
+            -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
+            -t $DOCKER_IMAGE_NAME:latest \
+            .
+  # release-integration:
+  #   permissions:
+  #     contents: write
+  #     pull-requests: write
+  #   uses: newrelic/k8s-metadata-injection/.github/workflows/release-integration-reusable.yml@main
+  #   with:
+  #     repo_name: newrelic-k8s-metrics-adapter
+  #     docker_image_name: newrelic/newrelic-k8s-metrics-adapter
+  #     chart_directory: charts/newrelic-k8s-metrics-adapter
+  #   secrets:
+  #     dockerhub_username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
+  #     dockerhub_token: ${{ secrets.FSI_DOCKERHUB_TOKEN }}
+  #     gh_token: ${{ secrets.GITHUB_TOKEN }}
+  #     slack_channel: ${{ secrets.K8S_AGENTS_SLACK_CHANNEL }}
+  #     slack_token: ${{ secrets.K8S_AGENTS_SLACK_TOKEN }}


### PR DESCRIPTION
## Which problem is this PR solving?

Test release docker image workflow with calling a reusable workflow

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Security fix
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## New Tests?
Please describe the new tests that were added (if applicable).

- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated