### PR TITLE
Fix: Test adding bin to binary image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG TARGETARCH
 # Some old-ish versions of Docker do not support adding and renaming in the same line, and will instead
 # interpret the second argument as a new folder to create and place the original file inside.
 # For this reason, we workaround with regular ADD and then run mv inside the container.
-ADD --chmod=755 newrelic-k8s-metrics-adapter-${TARGETOS}-${TARGETARCH} ./
+ADD --chmod=755 bin/newrelic-k8s-metrics-adapter-${TARGETOS}-${TARGETARCH} ./
 RUN mv newrelic-k8s-metrics-adapter-${TARGETOS}-${TARGETARCH} /usr/local/bin/newrelic-k8s-metrics-adapter
 
 ENTRYPOINT ["/usr/local/bin/newrelic-k8s-metrics-adapter"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # Use ?= for variable assignment so they can be overwritten with environment variables.
+BIN_DIR = ./bin
 GO_PACKAGES ?= ./...
 GO_TESTS ?= ^.*$
 GO_CMD ?= go
@@ -8,7 +9,7 @@ GOOS ?=
 GOARCH ?=
 CGO_ENABLED ?= 0
 
-BINARY_NAME ?= newrelic-k8s-metrics-adapter
+BINARY_NAME ?= $(BIN_DIR)/newrelic-k8s-metrics-adapter
 
 TAG ?= "dev"
 X_LD_FLAGS ?= -X 'github.com/newrelic/newrelic-k8s-metrics-adapter/internal/adapter.version=$(TAG)'


### PR DESCRIPTION
## Which problem is this PR solving?

Test adding bin to binary image and artifact path to match other k8s agents repos. 

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Security fix
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## New Tests?
Please describe the new tests that were added (if applicable).

- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated