### PR TITLE
ci: Add Slack notifications to all workflows that do not involve PRs

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -11,3 +11,5 @@ jobs:
     uses: newrelic/k8s-metadata-injection/.github/workflows/release-chart-reusable.yml@main
     secrets:
       gh_token: "${{ secrets.GITHUB_TOKEN }}"
+      slack_channel: ${{ secrets.K8S_AGENTS_SLACK_CHANNEL }}
+      slack_token: ${{ secrets.K8S_AGENTS_SLACK_TOKEN }}

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -1,4 +1,4 @@
-name: Release metrics adapter image
+name: Pre-release and Release pipeline
 
 on:
   release:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
Automate workflow notifications to Slack. That way we have only one source of truth to check for failing workflows.

For workflows that run for PRs, there is no need for automatic Slack notifications since merging will be blocked in the corresponding PR and author will be notified.
## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  