### PR TITLE
ci: Update minikube version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.9.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
-          minikube version: v1.30.1
+          minikube version: v1.31.2
           kubernetes version: ${{ matrix.kubernetes-version }}
           driver: docker
           github token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
Updating minikube version so Helm chart linting works for Kubernetes v 1.27

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  