### PR TITLE
feat: E2E testing: use `autoscaling/v2` instead of `autoscaling/v2beta2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### enhancement
+- E2E testing: use `autoscaling/v2` instead of `autoscaling/v2beta2` by @juanjjaramillo in [#252](https://github.com/newrelic/newrelic-k8s-metrics-adapter/pull/252)
 
 ### enhancement
 - Automate local integration and E2E testing by @juanjjaramillo in [#251](https://github.com/newrelic/newrelic-k8s-metrics-adapter/pull/251)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,29 +95,29 @@ func Test_Metrics_adapter_makes_sample_external_metric_available(t *testing.T) {
 
 				deploymentName := withTestDeployment(testEnv.Context, t, clientset.AppsV1().Deployments(ns))
 
-				client := clientset.AutoscalingV2beta2().HorizontalPodAutoscalers(ns)
+				client := clientset.AutoscalingV2().HorizontalPodAutoscalers(ns)
 
-				hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{
+				hpa := &autoscalingv2.HorizontalPodAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "newrelic-metrics-adapter-e2e-test",
 						Namespace:    ns,
 					},
-					Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
+					Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
 						MaxReplicas: 1,
-						ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+						ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 							Kind:       "Deployment",
 							APIVersion: "apps/v1",
 							Name:       deploymentName,
 						},
-						Metrics: []autoscalingv2beta2.MetricSpec{
+						Metrics: []autoscalingv2.MetricSpec{
 							{
-								Type: autoscalingv2beta2.ExternalMetricSourceType,
-								External: &autoscalingv2beta2.ExternalMetricSource{
-									Target: autoscalingv2beta2.MetricTarget{
+								Type: autoscalingv2.ExternalMetricSourceType,
+								External: &autoscalingv2.ExternalMetricSource{
+									Target: autoscalingv2.MetricTarget{
 										Type:  "Value",
 										Value: resource.NewQuantity(1, resource.DecimalSI),
 									},
-									Metric: autoscalingv2beta2.MetricIdentifier{
+									Metric: autoscalingv2.MetricIdentifier{
 										Name:     testMetric,
 										Selector: &testData,
 									},
@@ -155,9 +155,9 @@ func Test_Metrics_adapter_makes_sample_external_metric_available(t *testing.T) {
 						}
 
 						switch condition.Type {
-						case autoscalingv2beta2.ScalingActive:
+						case autoscalingv2.ScalingActive:
 							scalingActive = true
-						case autoscalingv2beta2.AbleToScale:
+						case autoscalingv2.AbleToScale:
 							ableToScale = true
 						default:
 							t.Logf("Ignoring condition %v", condition)

--- a/hack/kind-with-registry.sh
+++ b/hack/kind-with-registry.sh
@@ -12,7 +12,7 @@ if [ "${running}" != 'true' ]; then
 fi
 
 # create a cluster with the local registry enabled in containerd
-cat <<EOF | kind create cluster --image=kindest/node:v1.22.1 --config=-
+cat <<EOF | kind create cluster --image=kindest/node:v1.28.0 --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
HPA has been promoted to [stable](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [x] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [x] E2E tests
  