### PR TITLE
fix: potentially bad formatting prevented version increase and made everything weird

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## v0.16.1 - 2025-04-28
-
-### dependency
-- Updated golang.org/x/crypto to v0.35.0
+### security
+- Updated golang.org/x/crypto to v0.35.0 @TmNguyen12 [#394](https://github.com/newrelic/newrelic-k8s-metrics-adapter/pull/394)
 
 ## v0.16.1 - 2025-04-14
 


### PR DESCRIPTION
The supposed release on 4/28 never actually happened because the version didn't increase properly -> https://github.com/newrelic/newrelic-k8s-metrics-adapter/commit/04bf202b82d1ec8099c3d2483b43c0e422a6ccc9

I think the release toolkit didn't recognize `dependency` properly. The options for non-dependabot changes are `enhancement`, `security`, `bugfix`, and `breaking`.

## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  