### PR TITLE
chore: update alpine

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,4 +1,0 @@
-# Alpine 3.23.3 and golang-1.26-alpine (3.23) uses uses zlib 1.3.2-r0
-CVE-2026-22184
-CVE-2026-27171
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ FROM alpine:3.23.3
 ARG TARGETOS
 ARG TARGETARCH
 
+RUN apk upgrade --no-cache
+
 # Some old-ish versions of Docker do not support adding and renaming in the same line, and will instead
 # interpret the second argument as a new folder to create and place the original file inside.
 # For this reason, we workaround with regular ADD and then run mv inside the container.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.3
+FROM alpine:3.23.4
 
 # Set by Docker automatically.
 # If building with `docker build` directly, make sure to set GOOS/GOARCH explicitly when calling make:
@@ -8,8 +8,6 @@ FROM alpine:3.23.3
 # `docker build` for you.
 ARG TARGETOS
 ARG TARGETARCH
-
-RUN apk upgrade --no-cache
 
 # Some old-ish versions of Docker do not support adding and renaming in the same line, and will instead
 # interpret the second argument as a new folder to create and place the original file inside.


### PR DESCRIPTION
## Description
- Update alpine to version 3.23.4
- Removes .trivyignore as it was hiding some vulnerabilities

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [x] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](https://github.com/newrelic/newrelic-k8s-metrics-adapter/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  